### PR TITLE
Prepare package for Hackage upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
-# Revision history for extensible-sums
+# Revision history for summer
 
-## 0.1.0.0 -- YYYY-mm-dd
+## 0.4.0.0
+
+* Update for modern GHC (8.10.7 through 9.12.1)
+* Fix `consB` bug
+* Expand test coverage
+
+## 0.1.0.0
 
 * First version. Released on an unsuspecting world.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # summer
 
 [![Hackage](https://img.shields.io/hackage/v/summer.svg)](https://hackage.haskell.org/package/summer)
-[![Build Status](https://travis-ci.org/SamuelSchlesinger/summer.svg?branch=master)](https://travis-ci.org/SamuelSchlesinger/summer)
+[![Build Status](https://github.com/SamuelSchlesinger/summer/actions/workflows/haskell.yml/badge.svg)](https://github.com/SamuelSchlesinger/summer/actions/workflows/haskell.yml)
 
 
 Extensible sums and products for Haskell.

--- a/summer.cabal
+++ b/summer.cabal
@@ -9,9 +9,8 @@ author:              Samuel Schlesinger
 maintainer:          sgschlesinger@gmail.com
 copyright:           2020 Samuel Schlesinger
 category:            Data
-extra-source-files:  CHANGELOG.md, README.md
+extra-doc-files:     CHANGELOG.md, README.md
 build-type:          Simple
-extra-source-files:  CHANGELOG.md
 tested-with:         GHC ==8.10.7 || ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1
 
 source-repository head
@@ -21,7 +20,7 @@ source-repository head
 library
   exposed-modules:     Data.Summer, Data.Prodder
   other-modules:       Data.ForAll
-  build-depends:       base >=4.12 && <4.22, vector >=0.12, generics-sop >=0.5, profunctors >=5.6
+  build-depends:       base >=4.12 && <4.22, vector >=0.12 && <0.14, generics-sop >=0.5 && <0.6, profunctors >=5.6 && <5.7
   hs-source-dirs:      src
   default-language:    Haskell2010
 


### PR DESCRIPTION
## Summary
- Fix duplicate `extra-source-files` field and move to `extra-doc-files`
- Add upper bounds on `vector`, `generics-sop`, and `profunctors`
- Update CHANGELOG.md with 0.4.0.0 release notes
- Replace Travis CI badge with GitHub Actions badge

## Test plan
- [x] `cabal check` passes with no errors or warnings
- [x] `cabal build` succeeds
- [x] `cabal test` passes